### PR TITLE
fix: update CI working-directory forge-pgx -> pgx (T61 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: govulncheck ./...
 
   integration:
-    name: Test (forge-pgx integration)
+    name: Test (pgx integration)
     runs-on: ubuntu-latest
 
     services:
@@ -67,8 +67,8 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Run forge-pgx integration tests
-        working-directory: forge-pgx
+      - name: Run pgx integration tests
+        working-directory: pgx
         env:
           DATABASE_URL: postgres://forge:forge@localhost:5432/forgetest
         run: go test -v -tags integration ./...


### PR DESCRIPTION
CI integration job references the old forge-pgx working directory. T61 renamed it to pgx/ but the workflow was not updated. Fixes the No such file or directory failure. Two lines changed: job name + working-directory.