### PR TITLE
fix: bump pgx smeldr.dev/core dep v1.25.1 -> v1.29.0 (T62 follow-up)

### DIFF
--- a/pgx/go.mod
+++ b/pgx/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/jackc/pgx/v5 v5.8.0
-	smeldr.dev/core v1.25.1
+	smeldr.dev/core v1.29.0
 )
 
 require (

--- a/pgx/go.sum
+++ b/pgx/go.sum
@@ -44,5 +44,5 @@ modernc.org/memory v1.11.0 h1:o4QC8aMQzmcwCK3t3Ux/ZHmwFPzE6hf2Y5LbkRs+hbI=
 modernc.org/memory v1.11.0/go.mod h1:/JP4VbVC+K5sU2wZi9bHoq2MAkCnrt2r98UGeSK7Mjw=
 modernc.org/sqlite v1.50.0 h1:eMowQSWLK0MeiQTdmz3lqoF5dqclujdlIKeJA11+7oM=
 modernc.org/sqlite v1.50.0/go.mod h1:m0w8xhwYUVY3H6pSDwc3gkJ/irZT/0YEXwBlhaxQEew=
-smeldr.dev/core v1.25.1 h1:SKRjHUYIj6v7II3lYHICLxgr8mEGfWh20FV7dk227WA=
-smeldr.dev/core v1.25.1/go.mod h1:37nzRN/NmG34EXpPdcrZ8N7bKww6AVTmYsdj+BpsDps=
+smeldr.dev/core v1.29.0 h1:hTvf3miv3LoNfYL92mGf38d6g+I11zak32VbLTpC5Tw=
+smeldr.dev/core v1.29.0/go.mod h1:37nzRN/NmG34EXpPdcrZ8N7bKww6AVTmYsdj+BpsDps=


### PR DESCRIPTION
## Summary

- `pgx/go.mod`: `smeldr.dev/core v1.25.1` → `v1.29.0`
- `pgx/go.sum`: updated by `go mod tidy`

## Context

`pgx/go.mod` was pinned to `v1.25.1` — before the T62 package rename (`package forge` → `package smeldr`, shipped in `v1.26.0`). CI fails with `undefined: smeldr` because the downloaded `v1.25.1` still exports `package forge`.

## Test plan

- [ ] CI integration job (`Test (pgx integration)`) passes with bumped dependency