### PR TITLE
chore: strip UTF-8 BOM from Go source files

### DIFF
--- a/ai_test.go
+++ b/ai_test.go
@@ -1,4 +1,4 @@
-﻿package smeldr
+package smeldr
 
 import (
 	"compress/gzip"

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-﻿// Package forge is a Go web framework for content-first applications: structured
+// Package forge is a Go web framework for content-first applications: structured
 // content types with lifecycle management (draft → scheduled → published → archived),
 // AI indexing, RSS feeds, sitemaps, MCP tool support, and zero third-party runtime
 // dependencies.

--- a/example/api/main.go
+++ b/example/api/main.go
@@ -1,4 +1,4 @@
-﻿// Package main is a self-contained Forge JSON API — a Go resource curator —
+// Package main is a self-contained Forge JSON API — a Go resource curator —
 // demonstrating authentication, role-based authorisation, validation hooks,
 // and legacy URL redirects with no HTML templates.
 //

--- a/example/blog/main.go
+++ b/example/blog/main.go
@@ -1,4 +1,4 @@
-﻿// Package main is a self-contained Forge devlog — a production-pattern blog
+// Package main is a self-contained Forge devlog — a production-pattern blog
 // application that demonstrates the full v1.22.2 feature set:
 //
 //   - SQLite persistence via smeldr.SQLRepo (no cgo; uses modernc.org/sqlite)

--- a/example/docs/main.go
+++ b/example/docs/main.go
@@ -1,4 +1,4 @@
-﻿// Package main is a self-contained Forge documentation site — an example
+// Package main is a self-contained Forge documentation site — an example
 // application demonstrating Forge's AI-first content features:
 //
 //   - AIDoc per-item endpoints: /docs/{slug}/aidoc (token-efficient format)

--- a/example_test.go
+++ b/example_test.go
@@ -1,4 +1,4 @@
-﻿package smeldr
+package smeldr
 
 // example_test.go — compile-verified README examples.
 //

--- a/feed_test.go
+++ b/feed_test.go
@@ -1,4 +1,4 @@
-﻿package smeldr
+package smeldr
 
 import (
 	"context"

--- a/integration_full_test.go
+++ b/integration_full_test.go
@@ -1,4 +1,4 @@
-﻿package smeldr
+package smeldr
 
 // integration_full_test.go â€” cross-milestone integration suite (M1â€“M5).
 //

--- a/mcp_test.go
+++ b/mcp_test.go
@@ -1,4 +1,4 @@
-﻿package smeldr
+package smeldr
 
 import (
 	"testing"

--- a/module_test.go
+++ b/module_test.go
@@ -1,4 +1,4 @@
-﻿package smeldr
+package smeldr
 
 import (
 	"bytes"

--- a/node.go
+++ b/node.go
@@ -1,4 +1,4 @@
-﻿package smeldr
+package smeldr
 
 import (
 	"crypto/rand"

--- a/node_test.go
+++ b/node_test.go
@@ -1,4 +1,4 @@
-﻿package smeldr
+package smeldr
 
 import (
 	"strings"

--- a/signals_test.go
+++ b/signals_test.go
@@ -1,4 +1,4 @@
-﻿package smeldr
+package smeldr
 
 import (
 	"context"


### PR DESCRIPTION
## Summary

- Strips leading UTF-8 BOM (U+FEFF) introduced in PR #9 (merged 2026-05-29)
- Affected: 13 files (10 root-level + 3 under example/)
- Build and tests pass; no logic changes

## Merge

Squash to main. No version bump, no amendment.