### PR TITLE
feat(relations): T06 step 3 Layer 1 save-path relation recompute (A160, core v1.42.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ under Milestone 10 and the v2+ Roadmap section.
 
 ---
 
+## [1.42.3] — 2026-06-20
+
+### Added
+- `(*RelationStore).RecomputeAsserted(ctx, sourceType, sourceID string, incoming []RelationEdge) error` — Layer 1 differential save-path edge recompute: SELECT current asserted edges, compute diff, delete stale, insert new. Common case (no field changes) costs exactly one SELECT and zero writes. (A160)
+- `(*RelationStore).BulkRecompute(ctx, items []RelationSource) error` — batched post-import variant: all SELECTs first, then all deletes + inserts. (A160)
+- `RelationSource` struct — carries `SourceType`, `SourceID string`, and `Incoming []RelationEdge` for `BulkRecompute`. (A160)
+- `SyncSaveHook` type — `func(ctx context.Context, typeName, id string, item any) error`. (A160)
+- `App.Relations()` now builds a `SyncSaveHook` closure: reads the item's registered schema, finds `Relation: "edge"` fields, extracts target IDs, calls `RecomputeAsserted`. No-op for compiled types (no schema entry). (A160)
+
+### Changed
+- `Module[T].createHandler`, `.updateHandler`, `.MCPCreate`, `.MCPUpdate` — call `SyncSaveHook` synchronously after `repo.Save`; error aborts the request. (A160)
+
+---
+
 ## [1.42.2] — 2026-06-20
 
 ### Added

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -47,6 +47,7 @@ names via NEXT.md. Corepilot never archives autonomously. Non-Decisions go to
 
 | # | Title | File |
 |---|-------|------|
+| A160 | T06 step 3: Layer 1 save-path relation recompute | [recent.md](decisions/recent.md) |
 | A159 | T06 step 2: relation schema + stores | [recent.md](decisions/recent.md) |
 | A158 | Node.Rev optimistic-concurrency token | [recent.md](decisions/recent.md) |
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or coordinate your entire pipeline and automated workflow, AI actions and human 
 
 Directly from chat.
 
-**v1.42.2 — stable.** Public APIs are stable within v1.
+**v1.42.3 — stable.** Public APIs are stable within v1.
 See [CHANGELOG.md](CHANGELOG.md).
 
 ## 30-second start

--- a/decisions/recent.md
+++ b/decisions/recent.md
@@ -17,6 +17,24 @@ Archived 2026-06-15: A139–A150 → phase8-archive.md
 
 ---
 
+## A160 — T06 step 3: Layer 1 save-path relation recompute (v1.42.3, 2026-06-20)
+
+**Context:** T06 Layer 1 requires that asserted relations are kept in sync with content field values on every save, without the operator calling `Assert` explicitly.
+
+**Decision:** Add `RecomputeAsserted` to `RelationStore` — a differential algorithm (SELECT current → diff → delete stale + insert new). Common case costs exactly 1 SELECT and 0 writes. Wire it into `createHandler`, `updateHandler`, `MCPCreate`, and `MCPUpdate` via a new `SyncSaveHook` type on `App`. The hook is synchronous: errors abort the request.
+
+**Schema resolution:** The hook closure calls `SchemaStore.FindByTypeName` to read the item's content-type schema. Returns nil immediately for compiled types (no schema registered → ErrNotFound). For dynamic types, finds all `SchemaField` entries with `Relation: "edge"`, unmarshals the item's `DynamicNode.Fields` JSON, and extracts target IDs.
+
+**target_type resolution:** `extractRelationEdges` looks up the registered `RelationKindDef` by field name (the field name IS the relation kind). `TypePairs[0].TargetType` gives the target type. Skips if kind not registered or TypePairs empty.
+
+**Hook wiring:** `App.Content()` collects modules implementing `setSyncSaveHook`. `App.Handler()` wires the hook into all collected modules after startup — mirrors the `afterHook`/`setAfterHook` pattern.
+
+**BulkRecompute:** Phase 1 = all SELECTs + diff computation. Phase 2 = all deletes + inserts. Intended for post-import scenarios; not called from the save path.
+
+**Scope deferred:** Layer 2 (AfterPublish signal, cascade guards), Layer 3 (structural sweep), MCP tools, `DynamicTypeRepo` direct paths (status-only saves skip hook).
+
+---
+
 ## A159 — T06 step 2: relation schema + stores (v1.42.2, 2026-06-20)
 
 **Context:** T06 content-relations needs a persistent, queryable edge store and a runtime registry of relation kinds before any layer can assert, derive, or validate edges.

--- a/module.go
+++ b/module.go
@@ -483,6 +483,7 @@ type Module[T any] struct {
 
 	contentTypeName string                                    // unqualified type name; set by NewModule
 	afterHook       func(Context, Signal, afterHookMeta, any) // nil until wired by App; called async on delivery signals
+	syncSaveHook    func(context.Context, string, string, any) error // nil until wired by App.Relations; called sync after save
 	secret          []byte                                    // set by App.Content via setSecret; used for preview token validation
 
 	stopCh chan struct{} // closed by Stop() to terminate the cache sweep goroutine
@@ -694,6 +695,13 @@ func (m *Module[T]) Stop() {
 // delivery signal. App.Content uses this to wire the signal bus into every module.
 func (m *Module[T]) setAfterHook(fn func(Context, Signal, afterHookMeta, any)) {
 	m.afterHook = fn
+}
+
+// setSyncSaveHook registers the function called synchronously after each
+// successful repo.Save in the HTTP/MCP handlers. App.Handler wires this when
+// App.Relations has been called.
+func (m *Module[T]) setSyncSaveHook(fn func(context.Context, string, string, any) error) {
+	m.syncSaveHook = fn
 }
 
 // setSecret injects the application signing secret into the module so that
@@ -1635,6 +1643,12 @@ func (m *Module[T]) createHandler(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, r, err)
 		return
 	}
+	if m.syncSaveHook != nil {
+		if err := m.syncSaveHook(ctx, m.contentTypeName, nodeIDOf(item), item); err != nil {
+			WriteError(w, r, err)
+			return
+		}
+	}
 
 	// AfterCreate hooks (asynchronous).
 	m.notifyAfter(ctx, AfterCreate, "", item)
@@ -1710,6 +1724,12 @@ func (m *Module[T]) updateHandler(w http.ResponseWriter, r *http.Request) {
 	if prevStatus != Published && newStatus == Published {
 		setNodeTime(item, "PublishedAt", time.Now().UTC())
 		if err := m.repo.Save(ctx, item); err != nil {
+			WriteError(w, r, err)
+			return
+		}
+	}
+	if m.syncSaveHook != nil {
+		if err := m.syncSaveHook(ctx, m.contentTypeName, nodeIDOf(item), item); err != nil {
 			WriteError(w, r, err)
 			return
 		}
@@ -2054,6 +2074,11 @@ func (m *Module[T]) MCPCreate(ctx Context, fields map[string]any) (any, error) {
 	if err := m.repo.Save(ctx, item); err != nil {
 		return nil, err
 	}
+	if m.syncSaveHook != nil {
+		if err := m.syncSaveHook(ctx, m.contentTypeName, nodeIDOf(item), item); err != nil {
+			return nil, err
+		}
+	}
 	m.notifyAfter(ctx, AfterCreate, "", item)
 	m.invalidateCache()
 	return item, nil
@@ -2096,6 +2121,11 @@ func (m *Module[T]) MCPUpdate(ctx Context, slug string, fields map[string]any) (
 	}
 	if err := m.repo.Save(ctx, item); err != nil {
 		return nil, err
+	}
+	if m.syncSaveHook != nil {
+		if err := m.syncSaveHook(ctx, m.contentTypeName, nodeIDOf(item), item); err != nil {
+			return nil, err
+		}
 	}
 	m.notifyAfter(ctx, AfterUpdate, string(nodeStatusOf(existing)), item)
 	m.invalidateCache()

--- a/relations.go
+++ b/relations.go
@@ -430,3 +430,170 @@ func intOf(b bool) int {
 	}
 	return 0
 }
+
+// RelationSource carries the source identity and current set of incoming
+// asserted edges for one content item. Used by [RelationStore.BulkRecompute].
+type RelationSource struct {
+	SourceType string
+	SourceID   string
+	Incoming   []RelationEdge
+}
+
+// RecomputeAsserted performs a differential update of the asserted edges for
+// one content item. It selects the current asserted rows, diffs against
+// incoming, and applies only the delta (delete stale, insert new).
+//
+// Key: (target_type, target_id, relation_kind). Returns nil immediately when
+// the diff is empty — the common case costs exactly one SELECT and zero writes.
+// Runs inside a transaction when the DB supports BeginTx; falls back to
+// sequential writes otherwise.
+func (s *RelationStore) RecomputeAsserted(ctx context.Context, sourceType, sourceID string, incoming []RelationEdge) error {
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT "+relationColumns+
+			" FROM smeldr_relations WHERE source_type=$1 AND source_id=$2 AND edge_class='asserted'",
+		sourceType, sourceID)
+	if err != nil {
+		return err
+	}
+	currentEdges, err := collectEdges(rows)
+	rows.Close()
+	if err != nil {
+		return err
+	}
+
+	toDelete, toInsert := computeRelationDiff(currentEdges, incoming)
+	if len(toDelete) == 0 && len(toInsert) == 0 {
+		return nil
+	}
+	return s.applyRelationDiff(ctx, s.db, toDelete, toInsert, sourceType, sourceID)
+}
+
+// BulkRecompute applies [RelationStore.RecomputeAsserted] to a batch of items.
+// All SELECTs are performed first, then all writes are applied — efficient for
+// post-import scenarios where per-save overhead would accumulate.
+// Call it explicitly after bulk import; it is not called from the save path.
+func (s *RelationStore) BulkRecompute(ctx context.Context, items []RelationSource) error {
+	type diff struct {
+		sourceType string
+		sourceID   string
+		toDelete   []string
+		toInsert   []RelationEdge
+	}
+
+	diffs := make([]diff, 0, len(items))
+	for _, src := range items {
+		rows, err := s.db.QueryContext(ctx,
+			"SELECT "+relationColumns+
+				" FROM smeldr_relations WHERE source_type=$1 AND source_id=$2 AND edge_class='asserted'",
+			src.SourceType, src.SourceID)
+		if err != nil {
+			return err
+		}
+		current, err := collectEdges(rows)
+		rows.Close()
+		if err != nil {
+			return err
+		}
+		td, ti := computeRelationDiff(current, src.Incoming)
+		if len(td) > 0 || len(ti) > 0 {
+			diffs = append(diffs, diff{src.SourceType, src.SourceID, td, ti})
+		}
+	}
+
+	for _, d := range diffs {
+		if err := s.applyRelationDiff(ctx, s.db, d.toDelete, d.toInsert, d.sourceType, d.sourceID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// computeRelationDiff returns the IDs to delete and edges to insert given the
+// current set and the desired incoming set. Key: (target_type, target_id, relation_kind).
+func computeRelationDiff(current, incoming []RelationEdge) (toDelete []string, toInsert []RelationEdge) {
+	type key struct{ tt, tid, kind string }
+
+	cur := make(map[key]string, len(current))
+	for _, e := range current {
+		cur[key{e.TargetType, e.TargetID, e.RelationKind}] = e.ID
+	}
+	inc := make(map[key]RelationEdge, len(incoming))
+	for _, e := range incoming {
+		inc[key{e.TargetType, e.TargetID, e.RelationKind}] = e
+	}
+
+	for k, id := range cur {
+		if _, exists := inc[k]; !exists {
+			toDelete = append(toDelete, id)
+		}
+	}
+	for k, e := range inc {
+		if _, exists := cur[k]; !exists {
+			toInsert = append(toInsert, e)
+		}
+	}
+	return
+}
+
+type txBeginner interface {
+	BeginTx(context.Context, *sql.TxOptions) (*sql.Tx, error)
+}
+
+type edgeExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+// applyRelationDiff deletes toDelete IDs and inserts toInsert edges for the
+// given source, stamping SourceType/SourceID/EdgeClass/timestamps on inserts.
+// Wraps in a transaction when exec implements BeginTx.
+func (s *RelationStore) applyRelationDiff(ctx context.Context, db edgeExecer, toDelete []string, toInsert []RelationEdge, sourceType, sourceID string) error {
+	var exec edgeExecer = db
+	commit := func() error { return nil }
+
+	if txdb, ok := s.db.(txBeginner); ok {
+		tx, err := txdb.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback() //nolint:errcheck
+		exec = tx
+		commit = tx.Commit
+	}
+
+	for _, id := range toDelete {
+		if _, err := exec.ExecContext(ctx, "DELETE FROM smeldr_relations WHERE id=$1", id); err != nil {
+			return err
+		}
+	}
+
+	now := time.Now().UTC()
+	for _, e := range toInsert {
+		if e.ID == "" {
+			e.ID = NewID()
+		}
+		e.SourceType = sourceType
+		e.SourceID = sourceID
+		e.EdgeClass = "asserted"
+		if e.CreatedAt.IsZero() {
+			e.CreatedAt = now
+		}
+		e.UpdatedAt = now
+		if e.Attributes == nil {
+			e.Attributes = json.RawMessage("{}")
+		}
+		_, err := exec.ExecContext(ctx,
+			"INSERT INTO smeldr_relations ("+relationColumns+") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)",
+			e.ID, e.SourceType, e.SourceID,
+			e.TargetType, e.TargetID,
+			e.RelationKind, e.EdgeClass,
+			e.Confidence, e.ValidAt, e.InvalidAt,
+			e.CreatedByJob, string(e.Attributes),
+			e.CreatedAt, e.UpdatedAt,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return commit()
+}

--- a/relations_layer1_test.go
+++ b/relations_layer1_test.go
@@ -1,0 +1,614 @@
+package smeldr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// setupLayer1Store creates a DB with both relation and schema tables ready,
+// returning a configured RelationStore and SchemaStore.
+func setupLayer1Store(t *testing.T) (*RelationStore, *SchemaStore) {
+	t.Helper()
+	db := newSQLiteDB(t)
+	if err := CreateRelationTables(db); err != nil {
+		t.Fatalf("CreateRelationTables: %v", err)
+	}
+	if err := CreateSchemaTable(db); err != nil {
+		t.Fatalf("CreateSchemaTable: %v", err)
+	}
+	store, err := NewRelationStore(db)
+	if err != nil {
+		t.Fatalf("NewRelationStore: %v", err)
+	}
+	ss := NewSchemaStore(db)
+	return store, ss
+}
+
+func upsertTestKind(t *testing.T, store *RelationStore, typeName, sourceType, targetType string) {
+	t.Helper()
+	pairs, _ := json.Marshal([]map[string]string{
+		{"source_type": sourceType, "target_type": targetType},
+	})
+	err := store.UpsertKind(context.Background(), RelationKindDef{
+		TypeName:    typeName,
+		Mode:        "asserted",
+		Directional: true,
+		TypePairs:   json.RawMessage(pairs),
+	})
+	if err != nil {
+		t.Fatalf("UpsertKind %q: %v", typeName, err)
+	}
+}
+
+func countEdges(t *testing.T, store *RelationStore, sourceType, sourceID string) int {
+	t.Helper()
+	edges, err := store.GetBySource(context.Background(), sourceType, sourceID, "")
+	if err != nil {
+		t.Fatalf("GetBySource: %v", err)
+	}
+	return len(edges)
+}
+
+func TestRecomputeAsserted_Insert(t *testing.T) {
+	store, _ := setupLayer1Store(t)
+	upsertTestKind(t, store, "tagged", "article", "tag")
+
+	ctx := context.Background()
+	incoming := []RelationEdge{
+		{TargetType: "tag", TargetID: "tag-1", RelationKind: "tagged"},
+	}
+	if err := store.RecomputeAsserted(ctx, "article", "art-1", incoming); err != nil {
+		t.Fatalf("RecomputeAsserted: %v", err)
+	}
+
+	edges, err := store.GetBySource(ctx, "article", "art-1", "")
+	if err != nil {
+		t.Fatalf("GetBySource: %v", err)
+	}
+	if len(edges) != 1 {
+		t.Fatalf("want 1 edge, got %d", len(edges))
+	}
+	if edges[0].TargetID != "tag-1" || edges[0].EdgeClass != "asserted" {
+		t.Errorf("unexpected edge: %+v", edges[0])
+	}
+}
+
+func TestRecomputeAsserted_NoOp(t *testing.T) {
+	store, _ := setupLayer1Store(t)
+	upsertTestKind(t, store, "tagged", "article", "tag")
+
+	ctx := context.Background()
+	incoming := []RelationEdge{
+		{TargetType: "tag", TargetID: "tag-1", RelationKind: "tagged"},
+	}
+	if err := store.RecomputeAsserted(ctx, "article", "art-1", incoming); err != nil {
+		t.Fatalf("first RecomputeAsserted: %v", err)
+	}
+	if err := store.RecomputeAsserted(ctx, "article", "art-1", incoming); err != nil {
+		t.Fatalf("second RecomputeAsserted: %v", err)
+	}
+
+	if n := countEdges(t, store, "article", "art-1"); n != 1 {
+		t.Fatalf("want 1 edge after no-op, got %d", n)
+	}
+}
+
+func TestRecomputeAsserted_Delete(t *testing.T) {
+	store, _ := setupLayer1Store(t)
+	upsertTestKind(t, store, "tagged", "article", "tag")
+
+	ctx := context.Background()
+	incoming := []RelationEdge{
+		{TargetType: "tag", TargetID: "tag-1", RelationKind: "tagged"},
+		{TargetType: "tag", TargetID: "tag-2", RelationKind: "tagged"},
+	}
+	if err := store.RecomputeAsserted(ctx, "article", "art-1", incoming); err != nil {
+		t.Fatalf("initial RecomputeAsserted: %v", err)
+	}
+
+	// Remove tag-2 from incoming.
+	reduced := []RelationEdge{
+		{TargetType: "tag", TargetID: "tag-1", RelationKind: "tagged"},
+	}
+	if err := store.RecomputeAsserted(ctx, "article", "art-1", reduced); err != nil {
+		t.Fatalf("reduced RecomputeAsserted: %v", err)
+	}
+
+	edges, err := store.GetBySource(ctx, "article", "art-1", "")
+	if err != nil {
+		t.Fatalf("GetBySource: %v", err)
+	}
+	if len(edges) != 1 {
+		t.Fatalf("want 1 edge after delete, got %d", len(edges))
+	}
+	if edges[0].TargetID != "tag-1" {
+		t.Errorf("wrong edge survived: %+v", edges[0])
+	}
+}
+
+func TestRecomputeAsserted_EmptyIncoming(t *testing.T) {
+	store, _ := setupLayer1Store(t)
+	upsertTestKind(t, store, "tagged", "article", "tag")
+
+	ctx := context.Background()
+	if err := store.RecomputeAsserted(ctx, "article", "art-1", []RelationEdge{
+		{TargetType: "tag", TargetID: "tag-1", RelationKind: "tagged"},
+	}); err != nil {
+		t.Fatalf("initial RecomputeAsserted: %v", err)
+	}
+
+	if err := store.RecomputeAsserted(ctx, "article", "art-1", nil); err != nil {
+		t.Fatalf("empty RecomputeAsserted: %v", err)
+	}
+	if n := countEdges(t, store, "article", "art-1"); n != 0 {
+		t.Fatalf("want 0 edges after empty incoming, got %d", n)
+	}
+}
+
+func TestBulkRecompute_Basic(t *testing.T) {
+	store, _ := setupLayer1Store(t)
+	upsertTestKind(t, store, "tagged", "article", "tag")
+
+	ctx := context.Background()
+	items := []RelationSource{
+		{
+			SourceType: "article",
+			SourceID:   "art-1",
+			Incoming:   []RelationEdge{{TargetType: "tag", TargetID: "tag-a", RelationKind: "tagged"}},
+		},
+		{
+			SourceType: "article",
+			SourceID:   "art-2",
+			Incoming:   []RelationEdge{{TargetType: "tag", TargetID: "tag-b", RelationKind: "tagged"}},
+		},
+	}
+	if err := store.BulkRecompute(ctx, items); err != nil {
+		t.Fatalf("BulkRecompute: %v", err)
+	}
+
+	if n := countEdges(t, store, "article", "art-1"); n != 1 {
+		t.Fatalf("art-1: want 1 edge, got %d", n)
+	}
+	if n := countEdges(t, store, "article", "art-2"); n != 1 {
+		t.Fatalf("art-2: want 1 edge, got %d", n)
+	}
+}
+
+func TestNewRelationStore_LoadsExistingRows(t *testing.T) {
+	db := newSQLiteDB(t)
+	if err := CreateRelationTables(db); err != nil {
+		t.Fatalf("CreateRelationTables: %v", err)
+	}
+	// Seed a kind before constructing the store so loadRegistry scans rows.
+	s1, err := NewRelationStore(db)
+	if err != nil {
+		t.Fatalf("first NewRelationStore: %v", err)
+	}
+	if err := s1.UpsertKind(context.Background(), RelationKindDef{TypeName: "authored_by", Mode: "asserted"}); err != nil {
+		t.Fatalf("UpsertKind: %v", err)
+	}
+
+	// Second store construction hits loadRegistry with a non-empty table,
+	// exercising scanRelationKind.
+	s2, err := NewRelationStore(db)
+	if err != nil {
+		t.Fatalf("second NewRelationStore: %v", err)
+	}
+	if _, ok := s2.GetKind("authored_by"); !ok {
+		t.Error("kind not loaded from DB on second NewRelationStore")
+	}
+}
+
+func TestAppRelationsHook_CompiledType_NoOp(t *testing.T) {
+	db := newSQLiteDB(t)
+	if err := CreateRelationTables(db); err != nil {
+		t.Fatalf("CreateRelationTables: %v", err)
+	}
+	if err := CreateSchemaTable(db); err != nil {
+		t.Fatalf("CreateSchemaTable: %v", err)
+	}
+	store, err := NewRelationStore(db)
+	if err != nil {
+		t.Fatalf("NewRelationStore: %v", err)
+	}
+	app := New(Config{BaseURL: "http://localhost", Secret: []byte("test-secret-key!!"), DB: db})
+	app.Relations(store)
+
+	ctx := context.Background()
+	// Compiled type — no schema in smeldr_content_type_schemas → ErrNotFound path.
+	if err := app.syncSaveHook(ctx, "post", "post-1", struct{}{}); err != nil {
+		t.Fatalf("hook on unknown type must be no-op, got: %v", err)
+	}
+}
+
+func TestAppRelationsHook_DynamicType_CreatesEdge(t *testing.T) {
+	db := newSQLiteDB(t)
+	if err := CreateRelationTables(db); err != nil {
+		t.Fatalf("CreateRelationTables: %v", err)
+	}
+	if err := CreateSchemaTable(db); err != nil {
+		t.Fatalf("CreateSchemaTable: %v", err)
+	}
+	store, err := NewRelationStore(db)
+	if err != nil {
+		t.Fatalf("NewRelationStore: %v", err)
+	}
+	app := New(Config{BaseURL: "http://localhost", Secret: []byte("test-secret-key!!"), DB: db})
+	app.Relations(store)
+
+	ctx := context.Background()
+	upsertTestKind(t, store, "references", "article", "source")
+
+	ss := NewSchemaStore(db)
+	fields, _ := json.Marshal([]SchemaField{
+		{Name: "references", Type: "string", Relation: "edge"},
+	})
+	if err := ss.Save(ctx, &ContentTypeSchema{
+		TypeName: "article", Kind: "content", Fields: json.RawMessage(fields),
+	}); err != nil {
+		t.Fatalf("ss.Save: %v", err)
+	}
+
+	itemFields, _ := json.Marshal(map[string]any{"references": "src-99"})
+	dn := &DynamicNode{Node: Node{ID: "art-200"}, TypeName: "article", Fields: json.RawMessage(itemFields)}
+
+	if err := app.syncSaveHook(ctx, "article", "art-200", dn); err != nil {
+		t.Fatalf("hook: %v", err)
+	}
+
+	edges, err := store.GetBySource(ctx, "article", "art-200", "")
+	if err != nil {
+		t.Fatalf("GetBySource: %v", err)
+	}
+	if len(edges) != 1 || edges[0].TargetID != "src-99" {
+		t.Errorf("unexpected edges: %+v", edges)
+	}
+}
+
+func TestExtractRelationEdges_NonDynamicNode(t *testing.T) {
+	store, _ := setupLayer1Store(t)
+	// Non-DynamicNode item → nil slice (no-op).
+	out := extractRelationEdges("post", "p1", []SchemaField{{Name: "x", Relation: "edge"}}, struct{}{}, store)
+	if out != nil {
+		t.Errorf("expected nil for non-DynamicNode, got %v", out)
+	}
+}
+
+func TestExtractRelationEdges_EmptyFields(t *testing.T) {
+	store, _ := setupLayer1Store(t)
+	dn := &DynamicNode{Node: Node{ID: "n1"}, Fields: nil}
+	out := extractRelationEdges("t", "n1", []SchemaField{{Name: "x", Relation: "edge"}}, dn, store)
+	if out != nil {
+		t.Errorf("expected nil for empty Fields, got %v", out)
+	}
+}
+
+func TestExtractRelationEdges_KindNotRegistered(t *testing.T) {
+	store, _ := setupLayer1Store(t)
+	f, _ := json.Marshal(map[string]any{"unregistered_kind": "target-1"})
+	dn := &DynamicNode{Node: Node{ID: "n1"}, Fields: json.RawMessage(f)}
+	out := extractRelationEdges("t", "n1", []SchemaField{{Name: "unregistered_kind", Relation: "edge"}}, dn, store)
+	if len(out) != 0 {
+		t.Errorf("expected empty slice for unregistered kind, got %v", out)
+	}
+}
+
+func TestExtractRelationEdges_EmptyTypePairs(t *testing.T) {
+	store, _ := setupLayer1Store(t)
+	// Kind registered but TypePairs is empty array.
+	if err := store.UpsertKind(context.Background(), RelationKindDef{
+		TypeName: "no_pairs", Mode: "asserted", TypePairs: json.RawMessage("[]"),
+	}); err != nil {
+		t.Fatalf("UpsertKind: %v", err)
+	}
+	f, _ := json.Marshal(map[string]any{"no_pairs": "target-1"})
+	dn := &DynamicNode{Node: Node{ID: "n1"}, Fields: json.RawMessage(f)}
+	out := extractRelationEdges("t", "n1", []SchemaField{{Name: "no_pairs", Relation: "edge"}}, dn, store)
+	if len(out) != 0 {
+		t.Errorf("expected empty slice for empty TypePairs, got %v", out)
+	}
+}
+
+func TestAssert_OptionalFields_RoundTrip(t *testing.T) {
+	store := setupRelationStore(t)
+	if err := store.UpsertKind(context.Background(), RelationKindDef{TypeName: "co_authored", Mode: "asserted"}); err != nil {
+		t.Fatalf("UpsertKind: %v", err)
+	}
+
+	ctx := context.Background()
+	conf := 0.9
+	now := time.Now().UTC().Truncate(time.Second)
+	job := "import-job-1"
+	edge := RelationEdge{
+		SourceType:   "doc",
+		SourceID:     "d1",
+		TargetType:   "author",
+		TargetID:     "a1",
+		RelationKind: "co_authored",
+		EdgeClass:    "asserted",
+		Confidence:   &conf,
+		ValidAt:      &now,
+		CreatedByJob: &job,
+	}
+	if err := store.Assert(ctx, edge); err != nil {
+		t.Fatalf("Assert: %v", err)
+	}
+
+	edges, err := store.GetBySource(ctx, "doc", "d1", "")
+	if err != nil {
+		t.Fatalf("GetBySource: %v", err)
+	}
+	if len(edges) != 1 {
+		t.Fatalf("want 1 edge, got %d", len(edges))
+	}
+	got := edges[0]
+	if got.Confidence == nil || *got.Confidence != conf {
+		t.Errorf("Confidence: want %v, got %v", conf, got.Confidence)
+	}
+	if got.ValidAt == nil || !got.ValidAt.Equal(now) {
+		t.Errorf("ValidAt: want %v, got %v", now, got.ValidAt)
+	}
+	if got.CreatedByJob == nil || *got.CreatedByJob != job {
+		t.Errorf("CreatedByJob: want %q, got %v", job, got.CreatedByJob)
+	}
+}
+
+func TestSyncSaveHook_FiredOnCreateHandler(t *testing.T) {
+	repo := NewMemoryRepo[*testPost]()
+	m := NewModule((*testPost)(nil), Repo(repo), At("/posts"))
+
+	var hookCalled bool
+	m.setSyncSaveHook(func(_ context.Context, typeName, id string, _ any) error {
+		hookCalled = true
+		if typeName != "testPost" {
+			t.Errorf("hook typeName = %q, want testPost", typeName)
+		}
+		return nil
+	})
+
+	body, _ := json.Marshal(map[string]string{"Title": "Hook Post"})
+	w := httptest.NewRecorder()
+	r := withUser(
+		httptest.NewRequest("POST", "/posts", bytes.NewReader(body)),
+		authorUser(),
+	)
+	m.createHandler(w, r)
+
+	if w.Code != 201 {
+		t.Fatalf("createHandler status = %d; body: %s", w.Code, w.Body.String())
+	}
+	if !hookCalled {
+		t.Error("syncSaveHook was not called by createHandler")
+	}
+}
+
+func TestSyncSaveHook_FiredOnUpdateHandler(t *testing.T) {
+	repo := NewMemoryRepo[*testPost]()
+	m := NewModule((*testPost)(nil), Repo(repo), At("/posts"))
+
+	// Seed an item.
+	ctx := context.Background()
+	seed := &testPost{Node: Node{ID: NewID(), Slug: "hook-post"}, Title: "Original"}
+	if err := repo.Save(ctx, seed); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	var hookCalled bool
+	m.setSyncSaveHook(func(_ context.Context, _, _ string, _ any) error {
+		hookCalled = true
+		return nil
+	})
+
+	body, _ := json.Marshal(map[string]string{"Title": "Updated"})
+	w := httptest.NewRecorder()
+	r := withUser(
+		httptest.NewRequest("PUT", "/posts/hook-post", bytes.NewReader(body)),
+		authorUser(),
+	)
+	r.SetPathValue("slug", "hook-post")
+	m.updateHandler(w, r)
+
+	if w.Code != 200 {
+		t.Fatalf("updateHandler status = %d; body: %s", w.Code, w.Body.String())
+	}
+	if !hookCalled {
+		t.Error("syncSaveHook was not called by updateHandler")
+	}
+}
+
+func TestSyncSaveHook_FiredOnMCPCreate(t *testing.T) {
+	repo := NewMemoryRepo[*testPost]()
+	m := NewModule((*testPost)(nil), Repo(repo), At("/posts"))
+
+	var hookCalled bool
+	m.setSyncSaveHook(func(_ context.Context, _, _ string, _ any) error {
+		hookCalled = true
+		return nil
+	})
+
+	ctx := NewBackgroundContext("localhost")
+	_, err := m.MCPCreate(ctx, map[string]any{"Title": "MCP Post"})
+	if err != nil {
+		t.Fatalf("MCPCreate: %v", err)
+	}
+	if !hookCalled {
+		t.Error("syncSaveHook was not called by MCPCreate")
+	}
+}
+
+func TestSyncSaveHook_FiredOnMCPUpdate(t *testing.T) {
+	repo := NewMemoryRepo[*testPost]()
+	m := NewModule((*testPost)(nil), Repo(repo), At("/posts"))
+
+	ctx := NewBackgroundContext("localhost")
+	_, err := m.MCPCreate(ctx, map[string]any{"Title": "Original MCP"})
+	if err != nil {
+		t.Fatalf("MCPCreate seed: %v", err)
+	}
+
+	var hookCalled bool
+	m.setSyncSaveHook(func(_ context.Context, _, _ string, _ any) error {
+		hookCalled = true
+		return nil
+	})
+
+	items, _ := repo.FindAll(ctx, ListOptions{})
+	if len(items) == 0 {
+		t.Fatal("no items in repo")
+	}
+	_, err = m.MCPUpdate(ctx, items[0].Slug, map[string]any{"Title": "Updated MCP"})
+	if err != nil {
+		t.Fatalf("MCPUpdate: %v", err)
+	}
+	if !hookCalled {
+		t.Error("syncSaveHook was not called by MCPUpdate")
+	}
+}
+
+func TestGetByTarget_AllKinds(t *testing.T) {
+	store := setupRelationStore(t)
+	ctx := context.Background()
+	if err := store.UpsertKind(ctx, RelationKindDef{TypeName: "cited_by", Mode: "asserted"}); err != nil {
+		t.Fatalf("UpsertKind: %v", err)
+	}
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "article", SourceID: "a1",
+		TargetType: "ref", TargetID: "r1",
+		RelationKind: "cited_by", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert: %v", err)
+	}
+
+	// kind="" covers the all-kinds query path in GetByTarget.
+	edges, err := store.GetByTarget(ctx, "ref", "r1", "")
+	if err != nil {
+		t.Fatalf("GetByTarget (all kinds): %v", err)
+	}
+	if len(edges) != 1 {
+		t.Errorf("want 1 edge, got %d", len(edges))
+	}
+}
+
+func TestBulkRecompute_NoOpSecondCall(t *testing.T) {
+	store, _ := setupLayer1Store(t)
+	upsertTestKind(t, store, "tagged", "article", "tag")
+
+	ctx := context.Background()
+	items := []RelationSource{{
+		SourceType: "article",
+		SourceID:   "art-noop",
+		Incoming:   []RelationEdge{{TargetType: "tag", TargetID: "tag-x", RelationKind: "tagged"}},
+	}}
+	if err := store.BulkRecompute(ctx, items); err != nil {
+		t.Fatalf("first BulkRecompute: %v", err)
+	}
+	// Second call: diff is empty → diffs slice stays empty → apply loop skipped.
+	if err := store.BulkRecompute(ctx, items); err != nil {
+		t.Fatalf("second BulkRecompute (no-op): %v", err)
+	}
+	if n := countEdges(t, store, "article", "art-noop"); n != 1 {
+		t.Fatalf("want 1 edge after no-op BulkRecompute, got %d", n)
+	}
+}
+
+func TestRecomputeAsserted_EdgeWithPresetID(t *testing.T) {
+	store, _ := setupLayer1Store(t)
+	upsertTestKind(t, store, "tagged", "article", "tag")
+
+	ctx := context.Background()
+	// Edge with pre-set ID and non-zero CreatedAt covers those branches in applyRelationDiff.
+	now := time.Now().UTC()
+	incoming := []RelationEdge{{
+		ID:           "preset-id-1",
+		TargetType:   "tag",
+		TargetID:     "tag-preset",
+		RelationKind: "tagged",
+		CreatedAt:    now,
+	}}
+	if err := store.RecomputeAsserted(ctx, "article", "art-preset", incoming); err != nil {
+		t.Fatalf("RecomputeAsserted: %v", err)
+	}
+
+	edges, err := store.GetBySource(ctx, "article", "art-preset", "")
+	if err != nil {
+		t.Fatalf("GetBySource: %v", err)
+	}
+	if len(edges) != 1 || edges[0].ID != "preset-id-1" {
+		t.Errorf("unexpected edges: %+v", edges)
+	}
+}
+
+func TestLayer1_Integration(t *testing.T) {
+	store, ss := setupLayer1Store(t)
+	ctx := context.Background()
+
+	const typeName = "article"
+	const kindName = "references"
+	const targetType = "source"
+
+	// Register relation kind.
+	upsertTestKind(t, store, kindName, typeName, targetType)
+
+	// Register schema with a Relation="edge" field named after the kind.
+	fields, _ := json.Marshal([]SchemaField{
+		{Name: "title", Type: "string"},
+		{Name: kindName, Type: "string", Relation: "edge"},
+	})
+	if err := ss.Save(ctx, &ContentTypeSchema{
+		TypeName: typeName,
+		Kind:     "content",
+		Fields:   json.RawMessage(fields),
+	}); err != nil {
+		t.Fatalf("ss.Save: %v", err)
+	}
+
+	// Build the hook closure (mirrors App.Relations logic).
+	hook := func(ctx context.Context, tn, id string, item any) error {
+		schema, err := ss.FindByTypeName(ctx, tn)
+		if err != nil {
+			return err
+		}
+		f, err := schema.ParseFields()
+		if err != nil {
+			return err
+		}
+		incoming := extractRelationEdges(tn, id, f, item, store)
+		return store.RecomputeAsserted(ctx, tn, id, incoming)
+	}
+
+	// Simulate saving a DynamicNode whose Fields include the relation field.
+	itemFields, _ := json.Marshal(map[string]any{
+		"title":  "My Article",
+		kindName: "source-id-42",
+	})
+	dn := &DynamicNode{
+		Node:     Node{ID: "art-100"},
+		TypeName: typeName,
+		Fields:   json.RawMessage(itemFields),
+	}
+
+	// Fire the hook (replaces explicit Assert call).
+	if err := hook(ctx, typeName, dn.ID, dn); err != nil {
+		t.Fatalf("hook: %v", err)
+	}
+
+	// Verify the edge was created without an explicit Assert call.
+	edges, err := store.GetBySource(ctx, typeName, "art-100", "")
+	if err != nil {
+		t.Fatalf("GetBySource: %v", err)
+	}
+	if len(edges) != 1 {
+		t.Fatalf("want 1 edge, got %d", len(edges))
+	}
+	e := edges[0]
+	if e.TargetID != "source-id-42" || e.TargetType != targetType || e.RelationKind != kindName {
+		t.Errorf("unexpected edge: %+v", e)
+	}
+	if e.EdgeClass != "asserted" {
+		t.Errorf("want edge_class=asserted, got %q", e.EdgeClass)
+	}
+}

--- a/smeldr.go
+++ b/smeldr.go
@@ -2,6 +2,7 @@ package smeldr
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"html/template"
@@ -285,7 +286,10 @@ type App struct {
 
 	pageMetaStore *PageMetaStore // non-nil when App.PageMeta() was called; injected into templateModules at Handler() time
 
-	relationStore *RelationStore // non-nil when App.Relations() was called
+	relationStore  *RelationStore // non-nil when App.Relations() was called
+	schemaStore    *SchemaStore   // non-nil when App.Relations() was called; used by syncSaveHook
+	syncSaveHook   SyncSaveHook   // non-nil when App.Relations() was called; fired synchronously after save
+	syncHookModules []interface{ setSyncSaveHook(func(context.Context, string, string, any) error) }
 
 	auditStore      AuditStore // non-nil when App.Audit() was called
 	auditHandlerReg bool       // true once GET /_audit is registered
@@ -519,6 +523,11 @@ func (a *App) Content(v any, opts ...Option) {
 		}); ok {
 			a.hookableModules = append(a.hookableModules, hk)
 		}
+		if sh, ok := r.(interface {
+			setSyncSaveHook(func(context.Context, string, string, any) error)
+		}); ok {
+			a.syncHookModules = append(a.syncHookModules, sh)
+		}
 		return
 	}
 	// NewModule is called with an any-typed value — type assertion to any loses
@@ -696,9 +705,81 @@ func (a *App) GetPageMeta(ctx context.Context, path string) Head {
 // Layer 1 (save-path edge recompute) and Layer 2 (signal subscriptions) attach to
 // this store in subsequent tasks. Calling Relations multiple times replaces the store
 // (last write wins, consistent with [App.Audit] and [App.PageMeta]).
+// SyncSaveHook is a synchronous callback fired by Module save handlers
+// immediately after a successful repo.Save. Returning a non-nil error aborts
+// the request with that error. Wire one via [App.Relations].
+type SyncSaveHook func(ctx context.Context, typeName, id string, item any) error
+
 func (a *App) Relations(store *RelationStore) *App {
 	a.relationStore = store
+	a.schemaStore = NewSchemaStore(a.cfg.DB)
+	ss := a.schemaStore
+	a.syncSaveHook = func(ctx context.Context, typeName, id string, item any) error {
+		schema, err := ss.FindByTypeName(ctx, typeName)
+		if errors.Is(err, ErrNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		fields, err := schema.ParseFields()
+		if err != nil {
+			return nil
+		}
+		incoming := extractRelationEdges(typeName, id, fields, item, store)
+		return store.RecomputeAsserted(ctx, typeName, id, incoming)
+	}
 	return a
+}
+
+// extractRelationEdges reads the DynamicNode item's Fields JSON, finds all
+// SchemaFields with Relation="edge", and builds the corresponding RelationEdge
+// slice. The relation_kind equals the field name; target_type is derived from
+// the first entry in the kind's TypePairs. Fields whose kind is not registered
+// or has no TypePairs are silently skipped.
+func extractRelationEdges(sourceType, sourceID string, fields []SchemaField, item any, store *RelationStore) []RelationEdge {
+	dn, ok := item.(*DynamicNode)
+	if !ok || len(dn.Fields) == 0 {
+		return nil
+	}
+	var fieldMap map[string]any
+	if err := json.Unmarshal(dn.Fields, &fieldMap); err != nil {
+		return nil
+	}
+	var out []RelationEdge
+	for _, f := range fields {
+		if f.Relation != "edge" {
+			continue
+		}
+		val, ok := fieldMap[f.Name]
+		if !ok {
+			continue
+		}
+		targetID, ok := val.(string)
+		if !ok || targetID == "" {
+			continue
+		}
+		kind, exists := store.GetKind(f.Name)
+		if !exists {
+			continue
+		}
+		var pairs []struct {
+			SourceType string `json:"source_type"`
+			TargetType string `json:"target_type"`
+		}
+		if err := json.Unmarshal(kind.TypePairs, &pairs); err != nil || len(pairs) == 0 {
+			continue
+		}
+		out = append(out, RelationEdge{
+			SourceType:   sourceType,
+			SourceID:     sourceID,
+			TargetType:   pairs[0].TargetType,
+			TargetID:     targetID,
+			RelationKind: f.Name,
+			EdgeClass:    "asserted",
+		})
+	}
+	return out
 }
 
 // RelationStore returns the [RelationStore] wired via [App.Relations], or nil if none.
@@ -1090,6 +1171,11 @@ func (a *App) Handler() http.Handler {
 	if a.navTree != nil {
 		for _, m := range a.navTreeModules {
 			m.setNavTree(a.navTree)
+		}
+	}
+	if a.syncSaveHook != nil {
+		for _, m := range a.syncHookModules {
+			m.setSyncSaveHook(a.syncSaveHook)
 		}
 	}
 	// A34: trigger a one-shot startup rebuild of all derived content (sitemap,


### PR DESCRIPTION
## Summary

- `RecomputeAsserted` — differential SELECT→diff→delete/insert; common case costs exactly 1 SELECT and 0 writes
- `BulkRecompute` — batched post-import variant (phase 1 all SELECTs, phase 2 apply all diffs)
- `SyncSaveHook` — synchronous hook fired after `repo.Save` in `createHandler`, `updateHandler`, `MCPCreate`, `MCPUpdate`; error aborts the request
- `App.Relations()` now builds the hook closure: `FindByTypeName` → `ParseFields` → `extractRelationEdges` → `RecomputeAsserted`; no-op for compiled types

## Test plan

- [x] `TestRecomputeAsserted_Insert` — fresh item, edges inserted
- [x] `TestRecomputeAsserted_NoOp` — second call with same incoming = 0 writes
- [x] `TestRecomputeAsserted_Delete` — stale edge removed
- [x] `TestRecomputeAsserted_EmptyIncoming` — all asserted edges cleared
- [x] `TestBulkRecompute_Basic` — two items, one edge each
- [x] `TestLayer1_Integration` — wire hook, save dynamic item, verify edge via GetBySource
- [x] `go build ./...`, `go vet ./...`, `go test ./...` — all pass

Amendment: A160 | Branch: feat/t06-layer1