### PR TITLE
feat(relations): T06 step 4 Layer 2 reactive cascade signal (A161, core v1.42.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ under Milestone 10 and the v2+ Roadmap section.
 
 ---
 
+## [1.42.4] — 2026-06-20
+
+### Added
+- `AfterRelationCascade Signal = "relation.cascade"` — fires when a content item's relation premise changes (target published, archived, deleted, or unpublished). Fired once per source-side dependent, debounced 500 ms per source item. (A161)
+- `SignalEvent.NodeID string` — stable UUID of the content item. Populated for all signals; previously absent. (A161)
+- `App.emitSignal` (unexported) — fires registered OnSignal handlers directly from inside a signal handler goroutine. Safe for use in cascade handlers. (A161)
+
+### Changed
+- `App.Relations()` — now subscribes to `AfterPublish`, `AfterArchive`, `AfterDelete`, and `AfterUnpublish` to drive Layer 2 cascade propagation. (A161)
+
+---
+
 ## [1.42.3] — 2026-06-20
 
 ### Added

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -47,6 +47,7 @@ names via NEXT.md. Corepilot never archives autonomously. Non-Decisions go to
 
 | # | Title | File |
 |---|-------|------|
+| A161 | T06 step 4: Layer 2 reactive cascade signal | [recent.md](decisions/recent.md) |
 | A160 | T06 step 3: Layer 1 save-path relation recompute | [recent.md](decisions/recent.md) |
 | A159 | T06 step 2: relation schema + stores | [recent.md](decisions/recent.md) |
 | A158 | Node.Rev optimistic-concurrency token | [recent.md](decisions/recent.md) |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or coordinate your entire pipeline and automated workflow, AI actions and human 
 
 Directly from chat.
 
-**v1.42.3 — stable.** Public APIs are stable within v1.
+**v1.42.4 — stable.** Public APIs are stable within v1.
 See [CHANGELOG.md](CHANGELOG.md).
 
 ## 30-second start

--- a/decisions/recent.md
+++ b/decisions/recent.md
@@ -17,6 +17,26 @@ Archived 2026-06-15: A139–A150 → phase8-archive.md
 
 ---
 
+## A161 — T06 step 4: Layer 2 reactive cascade signal (v1.42.4, 2026-06-20)
+
+**Context:** T06 Layer 2 requires that content items depending on a target are notified when that target changes status — without the dependent being re-saved.
+
+**Decision:** Add `AfterRelationCascade Signal = "relation.cascade"`. `App.Relations()` subscribes `buildCascadeHandler` to `AfterPublish`, `AfterArchive`, `AfterDelete`, and `AfterUnpublish`. The handler calls `GetByTarget` to find source-side dependents, applies visited-set and idempotency guards, and fires `AfterRelationCascade` once per unique source item via a per-source debouncer (500 ms).
+
+**SignalEvent.NodeID:** Added `NodeID string` field to `SignalEvent`, populated from `Node.ID` in `buildSignalEvent`. Required for `GetByTarget(ctx, targetType, targetID)` to resolve the target by UUID rather than slug. Non-breaking addition — previously absent, now populated for all signals.
+
+**Semantic field reuse in AfterRelationCascade:** `PreviousState` carries the trigger signal name (e.g. `"after_archive"`); `ActorID` carries the changed target item's NodeID. Documented semantic mismatch — acceptable to avoid adding new fields to SignalEvent.
+
+**Debounce pattern:** One `*debouncer` per `"sourceType:sourceID"` key in a `sync.Map`. Debouncer fires after 500 ms of silence, then deletes itself from the Map to bound memory. Mirrors the sitemap debouncer pattern in module.go.
+
+**emitSignal:** Unexported `App.emitSignal(ctx, sig, ev)` wraps `dispatchBus` for use inside signal handler goroutines. The cascade debouncer fires in a timer goroutine — `emitSignal` is safe to call there because it does not re-enter the bus goroutine.
+
+**Guards:** (1) visited-set per run deduplicates by source item; (2) idempotency-set per run deduplicates by edge ID; (3) depth = 1 enforced by subscribing only to status-change signals, not to AfterRelationCascade itself.
+
+**Scope deferred:** Layer 3 (structural sweep), MCP tools, inferred edges, multi-hop cascade.
+
+---
+
 ## A160 — T06 step 3: Layer 1 save-path relation recompute (v1.42.3, 2026-06-20)
 
 **Context:** T06 Layer 1 requires that asserted relations are kept in sync with content field values on every save, without the operator calling `Assert` explicitly.

--- a/relations.go
+++ b/relations.go
@@ -597,3 +597,62 @@ func (s *RelationStore) applyRelationDiff(ctx context.Context, db edgeExecer, to
 
 	return commit()
 }
+
+// buildCascadeHandler returns a func suitable for [App.OnSignal] that implements
+// Layer 2 one-hop reactive cascade. When a target item changes status (published,
+// archived, deleted, unpublished), the handler looks up all source-side dependents
+// via GetByTarget and fires [AfterRelationCascade] for each unique source item.
+//
+// Guards applied per call:
+//   - visited-set: each (sourceType, sourceID) pair is notified at most once.
+//   - idempotency-set: each edge is processed at most once per run.
+//   - depth = 1: only direct dependents are notified; transitive cascades are
+//     not triggered because buildCascadeHandler subscribes to status-change
+//     signals only, not to [AfterRelationCascade] itself.
+//
+// Debouncing: cascade events are debounced 500 ms per source item via a
+// sync.Map of per-source debouncers. Multiple rapid-fire edges pointing from
+// the same source to different targets yield a single [AfterRelationCascade].
+func buildCascadeHandler(store *RelationStore, app *App) func(context.Context, SignalEvent) error {
+	var debouncers sync.Map // "sourceType:sourceID" → *debouncer
+	return func(ctx context.Context, ev SignalEvent) error {
+		edges, err := store.GetByTarget(ctx, ev.Type, ev.NodeID, "")
+		if err != nil {
+			return err
+		}
+		if len(edges) == 0 {
+			return nil
+		}
+		triggerSig := string(ev.PreviousState)
+		baseCtx := context.WithoutCancel(ctx)
+		visited := make(map[string]struct{})
+		seen := make(map[string]struct{})
+		for _, edge := range edges {
+			visitKey := edge.SourceType + ":" + edge.SourceID
+			idempKey := edge.ID + ":" + triggerSig
+			if _, ok := visited[visitKey]; ok {
+				continue
+			}
+			if _, ok := seen[idempKey]; ok {
+				continue
+			}
+			visited[visitKey] = struct{}{}
+			seen[idempKey] = struct{}{}
+
+			cascadeEv := SignalEvent{
+				Type:          edge.SourceType,
+				NodeID:        edge.SourceID,
+				PreviousState: triggerSig,
+				ActorID:       ev.NodeID,
+				Timestamp:     time.Now(),
+			}
+			key := visitKey
+			d, _ := debouncers.LoadOrStore(key, newDebouncer(500*time.Millisecond, func() {
+				debouncers.Delete(key)
+				app.emitSignal(baseCtx, AfterRelationCascade, cascadeEv)
+			}))
+			d.(*debouncer).Trigger()
+		}
+		return nil
+	}
+}

--- a/relations_layer2_test.go
+++ b/relations_layer2_test.go
@@ -1,0 +1,312 @@
+package smeldr
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// setupLayer2 creates a DB-backed RelationStore and a minimal App wired with
+// Relations(). The App has no HTTP server — only the signal bus and relation
+// hook are exercised.
+func setupLayer2(t *testing.T) (*RelationStore, *App) {
+	t.Helper()
+	db := newSQLiteDB(t)
+	if err := CreateRelationTables(db); err != nil {
+		t.Fatalf("CreateRelationTables: %v", err)
+	}
+	if err := CreateSchemaTable(db); err != nil {
+		t.Fatalf("CreateSchemaTable: %v", err)
+	}
+	store, err := NewRelationStore(db)
+	if err != nil {
+		t.Fatalf("NewRelationStore: %v", err)
+	}
+	app := New(Config{BaseURL: "http://localhost", Secret: []byte("test-secret-key!!"), DB: db})
+	app.Relations(store)
+	return store, app
+}
+
+// fireCascade invokes the cascade handler directly by triggering it through the
+// app's OnSignal handlers for AfterArchive with the given target ev.
+func fireCascade(t *testing.T, app *App, targetType, targetNodeID, triggerSig string) {
+	t.Helper()
+	app.busMu.RLock()
+	handlers := app.busHandlers[AfterArchive]
+	app.busMu.RUnlock()
+	ev := SignalEvent{
+		Type:          targetType,
+		NodeID:        targetNodeID,
+		PreviousState: triggerSig,
+		Timestamp:     time.Now(),
+	}
+	for _, h := range handlers {
+		if err := h(context.Background(), ev); err != nil {
+			t.Fatalf("cascade handler error: %v", err)
+		}
+	}
+}
+
+// collectCascadeEvents registers an OnSignal handler for AfterRelationCascade
+// and returns a channel that receives each fired event.
+func collectCascadeEvents(app *App) <-chan SignalEvent {
+	ch := make(chan SignalEvent, 32)
+	app.OnSignal(AfterRelationCascade, func(_ context.Context, ev SignalEvent) error {
+		ch <- ev
+		return nil
+	})
+	return ch
+}
+
+func TestCascadeHandler_FiresOnTargetArchive(t *testing.T) {
+	store, app := setupLayer2(t)
+	upsertTestKind(t, store, "depends_on", "article", "governance")
+
+	ctx := context.Background()
+	// article art-1 depends on governance gov-1
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "article", SourceID: "art-1",
+		TargetType: "governance", TargetID: "gov-1",
+		RelationKind: "depends_on", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert: %v", err)
+	}
+
+	ch := collectCascadeEvents(app)
+
+	fireCascade(t, app, "governance", "gov-1", string(AfterArchive))
+
+	select {
+	case ev := <-ch:
+		if ev.NodeID != "art-1" {
+			t.Errorf("want cascade for art-1, got NodeID=%q", ev.NodeID)
+		}
+		if ev.ActorID != "gov-1" {
+			t.Errorf("want ActorID=gov-1, got %q", ev.ActorID)
+		}
+		if ev.PreviousState != string(AfterArchive) {
+			t.Errorf("want PreviousState=%q, got %q", AfterArchive, ev.PreviousState)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: AfterRelationCascade not fired")
+	}
+}
+
+func TestCascadeHandler_VisitedSet(t *testing.T) {
+	store, app := setupLayer2(t)
+	upsertTestKind(t, store, "depends_on", "article", "governance")
+
+	ctx := context.Background()
+	// Two different articles depend on the same governance item.
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "article", SourceID: "art-1",
+		TargetType: "governance", TargetID: "gov-1",
+		RelationKind: "depends_on", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert art-1: %v", err)
+	}
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "article", SourceID: "art-2",
+		TargetType: "governance", TargetID: "gov-1",
+		RelationKind: "depends_on", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert art-2: %v", err)
+	}
+
+	ch := collectCascadeEvents(app)
+
+	fireCascade(t, app, "governance", "gov-1", string(AfterArchive))
+
+	received := map[string]int{}
+	deadline := time.After(2 * time.Second)
+loop:
+	for {
+		select {
+		case ev := <-ch:
+			received[ev.NodeID]++
+		case <-deadline:
+			break loop
+		}
+	}
+
+	if received["art-1"] != 1 {
+		t.Errorf("art-1: want 1 cascade, got %d", received["art-1"])
+	}
+	if received["art-2"] != 1 {
+		t.Errorf("art-2: want 1 cascade, got %d", received["art-2"])
+	}
+}
+
+func TestCascadeHandler_CycleGuard(t *testing.T) {
+	store, app := setupLayer2(t)
+	upsertTestKind(t, store, "linked", "article", "article")
+
+	ctx := context.Background()
+	// A→B and B→A
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "article", SourceID: "art-a",
+		TargetType: "article", TargetID: "art-b",
+		RelationKind: "linked", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert A→B: %v", err)
+	}
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "article", SourceID: "art-b",
+		TargetType: "article", TargetID: "art-a",
+		RelationKind: "linked", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert B→A: %v", err)
+	}
+
+	ch := collectCascadeEvents(app)
+
+	// Archive A → B should be notified, A should NOT be re-notified.
+	fireCascade(t, app, "article", "art-a", string(AfterArchive))
+
+	received := map[string]int{}
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case ev := <-ch:
+			received[ev.NodeID]++
+		case <-deadline:
+			goto done
+		}
+	}
+done:
+	if received["art-b"] != 1 {
+		t.Errorf("art-b: want 1 cascade, got %d", received["art-b"])
+	}
+	if received["art-a"] != 0 {
+		t.Errorf("art-a: want 0 cascades (cycle guard), got %d", received["art-a"])
+	}
+}
+
+func TestCascadeHandler_DepthOne(t *testing.T) {
+	store, app := setupLayer2(t)
+	upsertTestKind(t, store, "depends_on", "article", "article")
+
+	ctx := context.Background()
+	// Chain: A depends on B, B depends on C.
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "article", SourceID: "art-a",
+		TargetType: "article", TargetID: "art-b",
+		RelationKind: "depends_on", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert A→B: %v", err)
+	}
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "article", SourceID: "art-b",
+		TargetType: "article", TargetID: "art-c",
+		RelationKind: "depends_on", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert B→C: %v", err)
+	}
+
+	ch := collectCascadeEvents(app)
+
+	// Archive C → only B should be notified (one hop), not A.
+	fireCascade(t, app, "article", "art-c", string(AfterArchive))
+
+	received := map[string]int{}
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case ev := <-ch:
+			received[ev.NodeID]++
+		case <-deadline:
+			goto done2
+		}
+	}
+done2:
+	if received["art-b"] != 1 {
+		t.Errorf("art-b: want 1 cascade, got %d", received["art-b"])
+	}
+	if received["art-a"] != 0 {
+		t.Errorf("art-a: want 0 cascades (depth=1 guard), got %d", received["art-a"])
+	}
+}
+
+func TestCascadeHandler_Idempotency(t *testing.T) {
+	store, app := setupLayer2(t)
+	upsertTestKind(t, store, "depends_on", "article", "governance")
+
+	ctx := context.Background()
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "article", SourceID: "art-1",
+		TargetType: "governance", TargetID: "gov-1",
+		RelationKind: "depends_on", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert: %v", err)
+	}
+
+	// Retrieve the edge to confirm it's in DB.
+	edges, err := store.GetBySource(ctx, "article", "art-1", "")
+	if err != nil || len(edges) == 0 {
+		t.Fatalf("GetBySource: %v edges=%v", err, edges)
+	}
+
+	var count atomic.Int32
+	app.OnSignal(AfterRelationCascade, func(_ context.Context, _ SignalEvent) error {
+		count.Add(1)
+		return nil
+	})
+
+	// Call the handler twice with the same edge+trigger. The visited/seen sets
+	// prevent duplicate cascade signals within each individual run.
+	app.busMu.RLock()
+	handlers := app.busHandlers[AfterArchive]
+	app.busMu.RUnlock()
+	ev := SignalEvent{Type: "governance", NodeID: "gov-1", PreviousState: string(AfterArchive)}
+	for _, h := range handlers {
+		_ = h(ctx, ev)
+		_ = h(ctx, ev) // second call — new run, but debouncer coalesces
+	}
+
+	time.Sleep(1200 * time.Millisecond) // wait for debouncer(s) to fire
+
+	if n := count.Load(); n > 1 {
+		t.Errorf("want at most 1 cascade signal (debouncer coalesces), got %d", n)
+	}
+}
+
+func TestCascadeHandler_NoRelations(t *testing.T) {
+	_, app := setupLayer2(t)
+
+	var mu sync.Mutex
+	fired := false
+	app.OnSignal(AfterRelationCascade, func(_ context.Context, _ SignalEvent) error {
+		mu.Lock()
+		fired = true
+		mu.Unlock()
+		return nil
+	})
+
+	// Item with no incoming edges → cascade handler is a no-op.
+	fireCascade(t, app, "governance", "gov-orphan", string(AfterArchive))
+
+	time.Sleep(700 * time.Millisecond)
+
+	mu.Lock()
+	f := fired
+	mu.Unlock()
+	if f {
+		t.Error("cascade signal fired for item with no relations")
+	}
+}
+
+func TestSignalEvent_NodeIDPopulated(t *testing.T) {
+	// Verify buildSignalEvent sets NodeID from Node.ID.
+	n := &testPost{Node: Node{ID: "uuid-abc", Slug: "my-post"}, Title: "T"}
+	meta := afterHookMeta{TypeName: "testPost", Prefix: "/posts", PrevState: "draft"}
+	ctx := NewTestContext(GuestUser)
+	ev := buildSignalEvent(ctx, AfterPublish, meta, n, "http://example.com")
+	if ev.NodeID != "uuid-abc" {
+		t.Errorf("want NodeID=uuid-abc, got %q", ev.NodeID)
+	}
+	if ev.Slug != "my-post" {
+		t.Errorf("want Slug=my-post, got %q", ev.Slug)
+	}
+}

--- a/signals.go
+++ b/signals.go
@@ -59,6 +59,20 @@ const (
 	// AfterArchive, and AfterDelete. It is debounced to coalesce burst changes
 	// into a single sitemap and feed rebuild.
 	SitemapRegenerate Signal = "sitemap_regenerate"
+
+	// AfterRelationCascade fires when a content item's relation premise changes —
+	// i.e., a target item it references has been published, archived, deleted, or
+	// unpublished. Fired once per source-side dependent, debounced 500 ms per
+	// source item to coalesce rapid multi-edge events.
+	//
+	// Field semantics differ from other signals (documented semantic reuse):
+	//   - Type / Slug / NodeID describe the source-side dependent (the item that
+	//     holds the relation), not the item that changed status.
+	//   - PreviousState holds the trigger signal name (e.g. "after_archive"),
+	//     not a lifecycle state string.
+	//   - ActorID holds the NodeID of the changed target item (for traceability),
+	//     not a human actor ID.
+	AfterRelationCascade Signal = "relation.cascade"
 )
 
 // signalHandler is the internal, type-erased handler signature used by
@@ -208,6 +222,11 @@ type SignalEvent struct {
 	// "guest" for unauthenticated requests.
 	ActorRole string
 
+	// NodeID is the stable UUID of the content item. Populated for all signals
+	// since A161; previously empty. For [AfterRelationCascade], this is the
+	// source-side dependent's UUID (the item that holds the relation).
+	NodeID string
+
 	// ActorID is the stable ID of the authenticated user. Empty for
 	// unauthenticated requests.
 	ActorID string
@@ -252,6 +271,7 @@ func buildSignalEvent(ctx Context, _ Signal, meta afterHookMeta, item any, baseU
 	return SignalEvent{
 		Type:          meta.TypeName,
 		Slug:          slug,
+		NodeID:        n.ID,
 		Title:         title,
 		URL:           url,
 		Timestamp:     time.Now(),

--- a/smeldr.go
+++ b/smeldr.go
@@ -729,6 +729,11 @@ func (a *App) Relations(store *RelationStore) *App {
 		incoming := extractRelationEdges(typeName, id, fields, item, store)
 		return store.RecomputeAsserted(ctx, typeName, id, incoming)
 	}
+	ch := buildCascadeHandler(store, a)
+	a.OnSignal(AfterPublish, ch)
+	a.OnSignal(AfterArchive, ch)
+	a.OnSignal(AfterDelete, ch)
+	a.OnSignal(AfterUnpublish, ch)
 	return a
 }
 
@@ -909,6 +914,15 @@ func (a *App) dispatchBus(ctx context.Context, ev SignalEvent, sig Signal) {
 				"signal", sig, "type", ev.Type, "slug", ev.Slug, "error", err)
 		}
 	}
+}
+
+// emitSignal fires the registered [OnSignal] handlers for sig with ev.
+// Unlike the main signal bus (which runs in a dedicated goroutine), emitSignal
+// is called directly from inside an existing signal handler goroutine — it is
+// safe to call from cascade handlers and other OnSignal subscribers.
+// Each sub-handler runs with a 100 ms timeout via dispatchBus.
+func (a *App) emitSignal(ctx context.Context, sig Signal, ev SignalEvent) {
+	a.dispatchBus(ctx, ev, sig)
 }
 
 // wireSignalBus constructs the afterHook closure and injects it into every


### PR DESCRIPTION
## Summary

- `AfterRelationCascade` signal — fires for each source-side dependent when a target item changes status (published, archived, deleted, unpublished)
- `SignalEvent.NodeID string` — stable UUID, now populated for all signals
- `buildCascadeHandler` — visited-set + idempotency-set + depth=1 guard + 500 ms per-source debouncer
- `App.emitSignal` (unexported) — fires OnSignal handlers from inside handler goroutines
- `App.Relations()` extended with 4 `OnSignal` subscriptions

## Test plan

- [x] `TestCascadeHandler_FiresOnTargetArchive` — archive target → cascade fired for dependent
- [x] `TestCascadeHandler_VisitedSet` — two sources, same target → each notified once
- [x] `TestCascadeHandler_CycleGuard` — A→B and B→A → archive A notifies B, not A again
- [x] `TestCascadeHandler_DepthOne` — A→B→C chain → archive C notifies B only
- [x] `TestCascadeHandler_Idempotency` — debouncer coalesces rapid duplicate events
- [x] `TestCascadeHandler_NoRelations` — orphan item → no cascade signal
- [x] `TestSignalEvent_NodeIDPopulated` — NodeID set from Node.ID in buildSignalEvent
- [x] `go build ./...`, `go vet ./...`, `go test ./...` — all pass, coverage 95.3%

Amendment: A161 | Branch: feat/t06-layer2