### PR TITLE
feat(relations): T06 step 5 MCP relation tools (A162, core v1.42.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,22 @@ under Milestone 10 and the v2+ Roadmap section.
 
 ---
 
+## [1.42.5] — 2026-06-20
+
+### Added
+- `(*RelationStore).MCPAssertRelation(ctx, sourceType, sourceID, targetType, targetID, relationKind string, confidence *float64, validAt, invalidAt *time.Time, attributes json.RawMessage) (RelationEdge, error)` — manually asserts a typed edge; returns `ErrNotFound` if the kind is not registered. (A162)
+- `(*RelationStore).MCPProposeRelation(...)` — identical signature to `MCPAssertRelation` but stores `edge_class: "inferred"` for human or agent review. (A162)
+- `(*RelationStore).MCPGetRelations(ctx, typeName, id, direction, kind string) ([]RelationEdge, error)` — queries the relation graph; `direction` is `"source"`, `"target"`, or `"both"`; `kind=""` returns all kinds. (A162)
+- `(*RelationStore).MCPPreviewImpact(ctx, typeName, id string) ([]RelationEdge, error)` — dry-run: returns source-side dependents without firing any cascade signals. (A162)
+
+### Changed
+- `(*RelationStore).Assert` — now delegates to unexported `insertEdge`; behaviour unchanged. (A162)
+
+### Wiring
+`App.RelationStore()` is the gate for relation MCP tools. forge-mcp checks non-nil before registering the four tools.
+
+---
+
 ## [1.42.4] — 2026-06-20
 
 ### Added

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -47,6 +47,7 @@ names via NEXT.md. Corepilot never archives autonomously. Non-Decisions go to
 
 | # | Title | File |
 |---|-------|------|
+| A162 | T06 step 5: MCP relation tools | [recent.md](decisions/recent.md) |
 | A161 | T06 step 4: Layer 2 reactive cascade signal | [recent.md](decisions/recent.md) |
 | A160 | T06 step 3: Layer 1 save-path relation recompute | [recent.md](decisions/recent.md) |
 | A159 | T06 step 2: relation schema + stores | [recent.md](decisions/recent.md) |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or coordinate your entire pipeline and automated workflow, AI actions and human 
 
 Directly from chat.
 
-**v1.42.4 — stable.** Public APIs are stable within v1.
+**v1.42.5 — stable.** Public APIs are stable within v1.
 See [CHANGELOG.md](CHANGELOG.md).
 
 ## 30-second start

--- a/decisions/recent.md
+++ b/decisions/recent.md
@@ -17,6 +17,24 @@ Archived 2026-06-15: A139–A150 → phase8-archive.md
 
 ---
 
+## A162 — T06 step 5: MCP relation tools (v1.42.5, 2026-06-20)
+
+**Context:** T06 relation graph needs MCP-accessible tools so agents and operators can assert, query, and preview edges without direct DB access.
+
+**Decision:** Add four methods to `RelationStore`: `MCPAssertRelation`, `MCPProposeRelation`, `MCPGetRelations`, `MCPPreviewImpact`. Wired via `App.RelationStore()` — forge-mcp checks non-nil to gate registration. No new interface required; pattern mirrors `RedirectDB()`.
+
+**insertEdge refactor:** Shared unexported `insertEdge(ctx, edge) (RelationEdge, error)` extracted from `Assert`. Returns the populated edge with generated ID and timestamps. Both `Assert` and the MCP methods use it; `Assert` behaviour is unchanged.
+
+**propose_relation:** Stores `edge_class="inferred"` by calling `insertEdge` directly, bypassing `Assert`'s edge_class guard. The inferred edge is NOT automatically asserted — pending human or agent review.
+
+**Auth:** No role-check in RelationStore layer. Authorization is enforced by forge-mcp at tool-invoke time, identical to all other tools.
+
+**preview_impact:** Read-only dry-run. Calls `GetByTarget(ctx, type, id, "")` and returns source-side dependents. No signals are fired.
+
+**Scope deferred:** `upsert_relation_kind` DDL tool, Layer 3 sweep trigger, bulk import.
+
+---
+
 ## A161 — T06 step 4: Layer 2 reactive cascade signal (v1.42.4, 2026-06-20)
 
 **Context:** T06 Layer 2 requires that content items depending on a target are notified when that target changes status — without the dependent being re-saved.

--- a/relations.go
+++ b/relations.go
@@ -267,7 +267,14 @@ func (s *RelationStore) Assert(ctx context.Context, edge RelationEdge) error {
 	if edge.EdgeClass != "asserted" {
 		return Err("edge_class", "Assert only accepts edge_class=asserted")
 	}
+	_, err := s.insertEdge(ctx, edge)
+	return err
+}
 
+// insertEdge persists edge to smeldr_relations, generating an ID and timestamps
+// as needed. Returns the populated edge with all fields set. Called by Assert,
+// MCPAssertRelation, and MCPProposeRelation.
+func (s *RelationStore) insertEdge(ctx context.Context, edge RelationEdge) (RelationEdge, error) {
 	now := time.Now().UTC()
 	if edge.ID == "" {
 		edge.ID = NewID()
@@ -303,7 +310,91 @@ ON CONFLICT (id) DO UPDATE SET
 		edge.CreatedByJob, string(edge.Attributes),
 		edge.CreatedAt, edge.UpdatedAt,
 	)
-	return err
+	if err != nil {
+		return RelationEdge{}, err
+	}
+	return edge, nil
+}
+
+// MCPAssertRelation manually asserts a typed edge between two content items.
+// Returns ErrNotFound when relationKind is not registered. The edge is stored
+// with edge_class="asserted" and the populated RelationEdge is returned.
+func (s *RelationStore) MCPAssertRelation(ctx context.Context,
+	sourceType, sourceID, targetType, targetID, relationKind string,
+	confidence *float64, validAt, invalidAt *time.Time,
+	attributes json.RawMessage,
+) (RelationEdge, error) {
+	if _, ok := s.GetKind(relationKind); !ok {
+		return RelationEdge{}, ErrNotFound
+	}
+	return s.insertEdge(ctx, RelationEdge{
+		SourceType:   sourceType,
+		SourceID:     sourceID,
+		TargetType:   targetType,
+		TargetID:     targetID,
+		RelationKind: relationKind,
+		EdgeClass:    "asserted",
+		Confidence:   confidence,
+		ValidAt:      validAt,
+		InvalidAt:    invalidAt,
+		Attributes:   attributes,
+	})
+}
+
+// MCPProposeRelation records an inferred edge for human or agent review.
+// Identical to MCPAssertRelation but stores edge_class="inferred". The edge is
+// NOT automatically asserted — it remains pending review.
+func (s *RelationStore) MCPProposeRelation(ctx context.Context,
+	sourceType, sourceID, targetType, targetID, relationKind string,
+	confidence *float64, validAt, invalidAt *time.Time,
+	attributes json.RawMessage,
+) (RelationEdge, error) {
+	if _, ok := s.GetKind(relationKind); !ok {
+		return RelationEdge{}, ErrNotFound
+	}
+	return s.insertEdge(ctx, RelationEdge{
+		SourceType:   sourceType,
+		SourceID:     sourceID,
+		TargetType:   targetType,
+		TargetID:     targetID,
+		RelationKind: relationKind,
+		EdgeClass:    "inferred",
+		Confidence:   confidence,
+		ValidAt:      validAt,
+		InvalidAt:    invalidAt,
+		Attributes:   attributes,
+	})
+}
+
+// MCPGetRelations queries the relation graph for a given item.
+// direction must be "source", "target", or "both".
+// kind filters by relation kind; empty string returns all kinds.
+func (s *RelationStore) MCPGetRelations(ctx context.Context, typeName, id, direction, kind string) ([]RelationEdge, error) {
+	switch direction {
+	case "source":
+		return s.GetBySource(ctx, typeName, id, kind)
+	case "target":
+		return s.GetByTarget(ctx, typeName, id, kind)
+	case "both":
+		src, err := s.GetBySource(ctx, typeName, id, kind)
+		if err != nil {
+			return nil, err
+		}
+		tgt, err := s.GetByTarget(ctx, typeName, id, kind)
+		if err != nil {
+			return nil, err
+		}
+		return append(src, tgt...), nil
+	default:
+		return nil, fmt.Errorf("smeldr: MCPGetRelations: direction must be source, target, or both; got %q", direction)
+	}
+}
+
+// MCPPreviewImpact returns which items would receive an AfterRelationCascade
+// signal if the given item changed status — without firing any signals.
+// Returns the source-side dependents found via GetByTarget.
+func (s *RelationStore) MCPPreviewImpact(ctx context.Context, typeName, id string) ([]RelationEdge, error) {
+	return s.GetByTarget(ctx, typeName, id, "")
 }
 
 // GetBySource returns all edges where source_type and source_id match.

--- a/relations_mcp_test.go
+++ b/relations_mcp_test.go
@@ -1,0 +1,243 @@
+package smeldr
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func setupMCPRelations(t *testing.T) *RelationStore {
+	t.Helper()
+	db := newSQLiteDB(t)
+	if err := CreateRelationTables(db); err != nil {
+		t.Fatalf("CreateRelationTables: %v", err)
+	}
+	store, err := NewRelationStore(db)
+	if err != nil {
+		t.Fatalf("NewRelationStore: %v", err)
+	}
+	return store
+}
+
+func TestMCPAssertRelation_OK(t *testing.T) {
+	store := setupMCPRelations(t)
+	upsertTestKind(t, store, "tagged", "article", "tag")
+
+	ctx := context.Background()
+	edge, err := store.MCPAssertRelation(ctx, "article", "art-1", "tag", "tag-1", "tagged", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("MCPAssertRelation: %v", err)
+	}
+	if edge.ID == "" {
+		t.Error("want non-empty ID")
+	}
+	if edge.EdgeClass != "asserted" {
+		t.Errorf("want EdgeClass=asserted, got %q", edge.EdgeClass)
+	}
+	if edge.SourceID != "art-1" || edge.TargetID != "tag-1" {
+		t.Errorf("unexpected edge fields: %+v", edge)
+	}
+}
+
+func TestMCPAssertRelation_UnknownKind(t *testing.T) {
+	store := setupMCPRelations(t)
+
+	_, err := store.MCPAssertRelation(context.Background(), "article", "art-1", "tag", "tag-1", "nonexistent", nil, nil, nil, nil)
+	if err != ErrNotFound {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestMCPAssertRelation_WithConfidenceAndAttributes(t *testing.T) {
+	store := setupMCPRelations(t)
+	upsertTestKind(t, store, "tagged", "article", "tag")
+
+	conf := 0.9
+	attrs := json.RawMessage(`{"weight":1}`)
+	edge, err := store.MCPAssertRelation(context.Background(), "article", "art-1", "tag", "tag-1", "tagged", &conf, nil, nil, attrs)
+	if err != nil {
+		t.Fatalf("MCPAssertRelation: %v", err)
+	}
+	if edge.Confidence == nil || *edge.Confidence != 0.9 {
+		t.Errorf("want Confidence=0.9, got %v", edge.Confidence)
+	}
+}
+
+func TestMCPProposeRelation_StoresInferred(t *testing.T) {
+	store := setupMCPRelations(t)
+	upsertTestKind(t, store, "tagged", "article", "tag")
+
+	ctx := context.Background()
+	edge, err := store.MCPProposeRelation(ctx, "article", "art-1", "tag", "tag-1", "tagged", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("MCPProposeRelation: %v", err)
+	}
+	if edge.EdgeClass != "inferred" {
+		t.Errorf("want EdgeClass=inferred, got %q", edge.EdgeClass)
+	}
+
+	// Verify stored in DB with inferred class.
+	edges, err := store.GetBySource(ctx, "article", "art-1", "tagged")
+	if err != nil {
+		t.Fatalf("GetBySource: %v", err)
+	}
+	if len(edges) != 1 || edges[0].EdgeClass != "inferred" {
+		t.Errorf("expected 1 inferred edge in DB, got: %+v", edges)
+	}
+}
+
+func TestMCPGetRelations_Source(t *testing.T) {
+	store := setupMCPRelations(t)
+	upsertTestKind(t, store, "tagged", "article", "tag")
+
+	ctx := context.Background()
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "article", SourceID: "art-1",
+		TargetType: "tag", TargetID: "tag-1",
+		RelationKind: "tagged", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert: %v", err)
+	}
+
+	edges, err := store.MCPGetRelations(ctx, "article", "art-1", "source", "")
+	if err != nil {
+		t.Fatalf("MCPGetRelations source: %v", err)
+	}
+	if len(edges) != 1 || edges[0].TargetID != "tag-1" {
+		t.Errorf("unexpected edges: %+v", edges)
+	}
+}
+
+func TestMCPGetRelations_Target(t *testing.T) {
+	store := setupMCPRelations(t)
+	upsertTestKind(t, store, "tagged", "article", "tag")
+
+	ctx := context.Background()
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "article", SourceID: "art-1",
+		TargetType: "tag", TargetID: "tag-1",
+		RelationKind: "tagged", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert: %v", err)
+	}
+
+	edges, err := store.MCPGetRelations(ctx, "tag", "tag-1", "target", "")
+	if err != nil {
+		t.Fatalf("MCPGetRelations target: %v", err)
+	}
+	if len(edges) != 1 || edges[0].SourceID != "art-1" {
+		t.Errorf("unexpected edges: %+v", edges)
+	}
+}
+
+func TestMCPGetRelations_Both(t *testing.T) {
+	store := setupMCPRelations(t)
+	upsertTestKind(t, store, "tagged", "article", "tag")
+	upsertTestKind(t, store, "refs", "tag", "article")
+
+	ctx := context.Background()
+	// art-1 --tagged--> tag-1
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "article", SourceID: "art-1",
+		TargetType: "tag", TargetID: "tag-1",
+		RelationKind: "tagged", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert tagged: %v", err)
+	}
+	// tag-2 --refs--> art-1
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "tag", SourceID: "tag-2",
+		TargetType: "article", TargetID: "art-1",
+		RelationKind: "refs", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert refs: %v", err)
+	}
+
+	edges, err := store.MCPGetRelations(ctx, "article", "art-1", "both", "")
+	if err != nil {
+		t.Fatalf("MCPGetRelations both: %v", err)
+	}
+	if len(edges) != 2 {
+		t.Errorf("want 2 edges (1 source + 1 target), got %d: %+v", len(edges), edges)
+	}
+}
+
+func TestMCPGetRelations_KindFilter(t *testing.T) {
+	store := setupMCPRelations(t)
+	upsertTestKind(t, store, "tagged", "article", "tag")
+	upsertTestKind(t, store, "authored_by", "article", "author")
+
+	ctx := context.Background()
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "article", SourceID: "art-1",
+		TargetType: "tag", TargetID: "tag-1",
+		RelationKind: "tagged", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert tagged: %v", err)
+	}
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "article", SourceID: "art-1",
+		TargetType: "author", TargetID: "author-1",
+		RelationKind: "authored_by", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert authored_by: %v", err)
+	}
+
+	edges, err := store.MCPGetRelations(ctx, "article", "art-1", "source", "tagged")
+	if err != nil {
+		t.Fatalf("MCPGetRelations kind filter: %v", err)
+	}
+	if len(edges) != 1 || edges[0].RelationKind != "tagged" {
+		t.Errorf("want 1 edge with kind=tagged, got: %+v", edges)
+	}
+}
+
+func TestMCPPreviewImpact_ReturnsDependents(t *testing.T) {
+	store := setupMCPRelations(t)
+	upsertTestKind(t, store, "depends_on", "article", "governance")
+
+	ctx := context.Background()
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "article", SourceID: "art-1",
+		TargetType: "governance", TargetID: "gov-1",
+		RelationKind: "depends_on", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert: %v", err)
+	}
+	if err := store.Assert(ctx, RelationEdge{
+		SourceType: "article", SourceID: "art-2",
+		TargetType: "governance", TargetID: "gov-1",
+		RelationKind: "depends_on", EdgeClass: "asserted",
+	}); err != nil {
+		t.Fatalf("Assert art-2: %v", err)
+	}
+
+	edges, err := store.MCPPreviewImpact(ctx, "governance", "gov-1")
+	if err != nil {
+		t.Fatalf("MCPPreviewImpact: %v", err)
+	}
+	if len(edges) != 2 {
+		t.Errorf("want 2 dependents, got %d: %+v", len(edges), edges)
+	}
+}
+
+func TestMCPPreviewImpact_NoDependents(t *testing.T) {
+	store := setupMCPRelations(t)
+
+	edges, err := store.MCPPreviewImpact(context.Background(), "governance", "gov-orphan")
+	if err != nil {
+		t.Fatalf("MCPPreviewImpact: %v", err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("want empty, got %d edges", len(edges))
+	}
+}
+
+func TestMCPGetRelations_InvalidDirection(t *testing.T) {
+	store := setupMCPRelations(t)
+
+	_, err := store.MCPGetRelations(context.Background(), "article", "art-1", "sideways", "")
+	if err == nil {
+		t.Error("want error for invalid direction, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- `MCPAssertRelation` — asserts a typed edge; `ErrNotFound` if kind unknown
- `MCPProposeRelation` — identical but `edge_class="inferred"` for review
- `MCPGetRelations` — source/target/both direction + optional kind filter
- `MCPPreviewImpact` — dry-run: returns dependents, no signals fired
- `insertEdge` (unexported) — refactored from Assert; returns populated RelationEdge
- Gate: `App.RelationStore() != nil` → forge-mcp registers 4 tools

## Test plan

- [x] `TestMCPAssertRelation_OK` — valid edge → RelationEdge returned
- [x] `TestMCPAssertRelation_UnknownKind` → ErrNotFound
- [x] `TestMCPAssertRelation_WithConfidenceAndAttributes` — optional fields set
- [x] `TestMCPProposeRelation_StoresInferred` — edge_class=inferred in DB
- [x] `TestMCPGetRelations_Source` / `_Target` / `_Both` / `_KindFilter`
- [x] `TestMCPPreviewImpact_ReturnsDependents` / `_NoDependents`
- [x] `TestMCPGetRelations_InvalidDirection` — error on bad direction
- [x] All pass, coverage 95.3%

Amendment: A162 | Branch: feat/t06-mcp-relations