### PR TITLE
feat(relations): T06 step 6 MCP relation kind tools (A163, core v1.42.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ under Milestone 10 and the v2+ Roadmap section.
 
 ---
 
+## [1.42.6] — 2026-06-20
+
+### Added
+- `(*RelationStore).MCPUpsertRelationKind(ctx context.Context, def RelationKindDef) (RelationKindDef, error)` — registers or updates a relation kind; validates via `ValidateRelationKindDef`, persists, and returns the stored definition with generated ID and timestamps. Returns an error on invalid `mode` or empty `type_name`. (A163)
+- `(*RelationStore).MCPListRelationKinds() []RelationKindDef` — returns all registered relation kinds sorted by `type_name`; always returns a non-nil slice. (A163)
+
+### Notes
+These two tools complete the MCP surface for T06. Agents can now register kinds and assert/query/preview relations entirely through MCP without touching application code.
+
+Gate: `App.RelationStore() != nil` — forge-mcp checks this before registering both tools.
+
+---
+
 ## [1.42.5] — 2026-06-20
 
 ### Added

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -47,6 +47,7 @@ names via NEXT.md. Corepilot never archives autonomously. Non-Decisions go to
 
 | # | Title | File |
 |---|-------|------|
+| A163 | T06 step 6: MCP relation kind tools | [recent.md](decisions/recent.md) |
 | A162 | T06 step 5: MCP relation tools | [recent.md](decisions/recent.md) |
 | A161 | T06 step 4: Layer 2 reactive cascade signal | [recent.md](decisions/recent.md) |
 | A160 | T06 step 3: Layer 1 save-path relation recompute | [recent.md](decisions/recent.md) |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or coordinate your entire pipeline and automated workflow, AI actions and human 
 
 Directly from chat.
 
-**v1.42.5 — stable.** Public APIs are stable within v1.
+**v1.42.6 — stable.** Public APIs are stable within v1.
 See [CHANGELOG.md](CHANGELOG.md).
 
 ## 30-second start

--- a/decisions/recent.md
+++ b/decisions/recent.md
@@ -17,6 +17,18 @@ Archived 2026-06-15: A139–A150 → phase8-archive.md
 
 ---
 
+## A163 — T06 step 6: MCP relation kind tools (v1.42.6, 2026-06-20)
+
+**Context:** T06 agents need to manage the relation kind registry through MCP — not just query and assert edges, but also register and inspect kinds dynamically.
+
+**Decision:** Add two thin wrapper methods to `RelationStore`: `MCPUpsertRelationKind` and `MCPListRelationKinds`. Both delegate to existing `UpsertKind`/`ListKinds`. `MCPUpsertRelationKind` returns the stored `RelationKindDef` (with generated ID and timestamps) so callers don't need a follow-up `GetKind`. `MCPListRelationKinds` always returns a non-nil slice to simplify forge-mcp serialisation.
+
+**Completeness:** These two tools complete the MCP surface for T06. Agents can now register kinds and assert/query/preview relations entirely through MCP without touching application code.
+
+**Deferred:** `delete_relation_kind` (requires cascade handling on existing edges), `get_relation_kind` (agents can use list + client-side filter).
+
+---
+
 ## A162 — T06 step 5: MCP relation tools (v1.42.5, 2026-06-20)
 
 **Context:** T06 relation graph needs MCP-accessible tools so agents and operators can assert, query, and preview edges without direct DB access.

--- a/relations.go
+++ b/relations.go
@@ -397,6 +397,23 @@ func (s *RelationStore) MCPPreviewImpact(ctx context.Context, typeName, id strin
 	return s.GetByTarget(ctx, typeName, id, "")
 }
 
+// MCPUpsertRelationKind registers or updates a relation kind via MCP.
+// Delegates to UpsertKind (which validates and persists), then returns
+// the stored RelationKindDef from the in-memory registry.
+func (s *RelationStore) MCPUpsertRelationKind(ctx context.Context, def RelationKindDef) (RelationKindDef, error) {
+	if err := s.UpsertKind(ctx, def); err != nil {
+		return RelationKindDef{}, err
+	}
+	stored, _ := s.GetKind(def.TypeName)
+	return stored, nil
+}
+
+// MCPListRelationKinds returns all registered relation kinds sorted by type_name.
+// Thin wrapper over ListKinds so forge-mcp has a uniform MCPXxx naming convention.
+func (s *RelationStore) MCPListRelationKinds() []RelationKindDef {
+	return s.ListKinds()
+}
+
 // GetBySource returns all edges where source_type and source_id match.
 // If kind is non-empty, only edges with that relation_kind are returned.
 func (s *RelationStore) GetBySource(ctx context.Context, sourceType, sourceID, kind string) ([]RelationEdge, error) {

--- a/relations_kinds_mcp_test.go
+++ b/relations_kinds_mcp_test.go
@@ -1,0 +1,107 @@
+package smeldr
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMCPUpsertRelationKind_OK(t *testing.T) {
+	store := setupMCPRelations(t)
+
+	def := RelationKindDef{
+		TypeName: "tagged",
+		Label:    "Tagged",
+		Mode:     "asserted",
+	}
+	got, err := store.MCPUpsertRelationKind(context.Background(), def)
+	if err != nil {
+		t.Fatalf("MCPUpsertRelationKind: %v", err)
+	}
+	if got.TypeName != "tagged" {
+		t.Errorf("want TypeName=tagged, got %q", got.TypeName)
+	}
+	if got.ID == "" {
+		t.Error("want non-empty ID")
+	}
+	if got.CreatedAt.IsZero() {
+		t.Error("want non-zero CreatedAt")
+	}
+}
+
+func TestMCPUpsertRelationKind_InvalidMode(t *testing.T) {
+	store := setupMCPRelations(t)
+
+	_, err := store.MCPUpsertRelationKind(context.Background(), RelationKindDef{
+		TypeName: "bad",
+		Label:    "Bad",
+		Mode:     "unknown",
+	})
+	if err == nil {
+		t.Error("want error for invalid mode, got nil")
+	}
+}
+
+func TestMCPUpsertRelationKind_Upsert(t *testing.T) {
+	store := setupMCPRelations(t)
+
+	ctx := context.Background()
+	first := RelationKindDef{TypeName: "tagged", Label: "Tagged", Mode: "asserted"}
+	if _, err := store.MCPUpsertRelationKind(ctx, first); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+
+	second := RelationKindDef{TypeName: "tagged", Label: "Tagged v2", Mode: "inferable"}
+	got, err := store.MCPUpsertRelationKind(ctx, second)
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if got.Label != "Tagged v2" {
+		t.Errorf("want Label=Tagged v2 after update, got %q", got.Label)
+	}
+	if got.Mode != "inferable" {
+		t.Errorf("want Mode=inferable after update, got %q", got.Mode)
+	}
+
+	// Registry must not contain duplicates.
+	kinds := store.MCPListRelationKinds()
+	if len(kinds) != 1 {
+		t.Errorf("want exactly 1 kind after two upserts of same type_name, got %d", len(kinds))
+	}
+}
+
+func TestMCPListRelationKinds_Empty(t *testing.T) {
+	store := setupMCPRelations(t)
+
+	kinds := store.MCPListRelationKinds()
+	if kinds == nil {
+		t.Error("want non-nil empty slice, got nil")
+	}
+	if len(kinds) != 0 {
+		t.Errorf("want 0 kinds, got %d", len(kinds))
+	}
+}
+
+func TestMCPListRelationKinds_ReturnsSorted(t *testing.T) {
+	store := setupMCPRelations(t)
+
+	ctx := context.Background()
+	for _, name := range []string{"zzz_kind", "aaa_kind", "mmm_kind"} {
+		if _, err := store.MCPUpsertRelationKind(ctx, RelationKindDef{
+			TypeName: name,
+			Label:    name,
+			Mode:     "asserted",
+		}); err != nil {
+			t.Fatalf("MCPUpsertRelationKind %q: %v", name, err)
+		}
+	}
+
+	kinds := store.MCPListRelationKinds()
+	if len(kinds) != 3 {
+		t.Fatalf("want 3 kinds, got %d", len(kinds))
+	}
+	for i, want := range []string{"aaa_kind", "mmm_kind", "zzz_kind"} {
+		if kinds[i].TypeName != want {
+			t.Errorf("kinds[%d]: want %q, got %q", i, want, kinds[i].TypeName)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `MCPUpsertRelationKind` — register or update a relation kind; validates, persists, returns stored `RelationKindDef` with ID and timestamps
- `MCPListRelationKinds` — list all registered kinds sorted by `type_name`; always non-nil
- Completes T06 MCP surface — agents can now register kinds and assert/query/preview relations entirely through MCP without touching application code
- Gate: `App.RelationStore() != nil`

## Test plan

- [x] `TestMCPUpsertRelationKind_OK` — valid kind → stored, returned with ID
- [x] `TestMCPUpsertRelationKind_InvalidMode` — mode="unknown" → error
- [x] `TestMCPUpsertRelationKind_Upsert` — upsert same type_name twice → second write wins, no duplicate
- [x] `TestMCPListRelationKinds_Empty` — no kinds → empty slice (not nil)
- [x] `TestMCPListRelationKinds_ReturnsSorted` — 3 kinds → sorted by type_name
- [x] All pass, coverage 95.3%

Amendment: A163 | Branch: feat/t06-mcp-relation-kinds